### PR TITLE
Renaming the package for Wildbook IA

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-|CircleCI| |Travis| |Appveyor| |Codecov| |Pypi| |Downloads| |ReadTheDocs|
+|Travis| |Pypi|
 
 
 Hessian Affine + SIFT keypoints in Python
@@ -71,17 +71,7 @@ NOTES
 Requires opencv. On ubuntu you can: ``sudo apt-get install libopencv-dev``. You can also build / use wheels. 
 
 
-.. |CircleCI| image:: https://circleci.com/gh/Erotemic/hesaff.svg?style=svg
-    :target: https://circleci.com/gh/Erotemic/hesaff
-.. |Travis| image:: https://img.shields.io/travis/Erotemic/hesaff/master.svg?label=Travis%20CI
-   :target: https://travis-ci.org/Erotemic/hesaff?branch=master
-.. |Appveyor| image:: https://ci.appveyor.com/api/projects/status/github/Erotemic/hesaff?branch=master&svg=True
-   :target: https://ci.appveyor.com/project/Erotemic/hesaff/branch/master
-.. |Codecov| image:: https://codecov.io/github/Erotemic/hesaff/badge.svg?branch=master&service=github
-   :target: https://codecov.io/github/Erotemic/hesaff?branch=master
+.. |Travis| image:: https://img.shields.io/travis/WildbookOrg/hesaff/master.svg?label=Travis%20CI
+   :target: https://travis-ci.org/WildbookOrg/hesaff?branch=master
 .. |Pypi| image:: https://img.shields.io/pypi/v/hesaff.svg
-   :target: https://pypi.python.org/pypi/hesaff
-.. |Downloads| image:: https://img.shields.io/pypi/dm/hesaff.svg
-   :target: https://pypistats.org/packages/hesaff
-.. |ReadTheDocs| image:: https://readthedocs.org/projects/hesaff/badge/?version=latest
-    :target: http://hesaff.readthedocs.io/en/latest/
+   :target: https://pypi.python.org/pypi/wbia-pyhesaff

--- a/setup.py
+++ b/setup.py
@@ -161,44 +161,35 @@ except Exception:
     raise RuntimeError('FAILED TO ADD BUILD CONSTRUCTS')
 
 
-NAME = 'pyhesaff'
+NAME = 'wbia-pyhesaff'
 
 
 MB_PYTHON_TAG = native_mb_python_tag()  # NOQA
 VERSION = version = parse_version('pyhesaff/__init__.py')  # must be global for git tags
 
-ORIGINAL_AUTHORS = 'Krystian Mikolajczyk, Michal Perdoch'
-EXTENDED_AUTHORS = 'Jon Crall, Avi Weinstock'
+ORIGINAL_AUTHORS = ['Krystian Mikolajczyk', 'Michal Perdoch']
+EXTENDED_AUTHORS = ['Jon Crall', 'Avi Weinstock']
+CURRENT_AUTHORS = ['WildMe Developers']
 
-AUTHORS = ORIGINAL_AUTHORS + EXTENDED_AUTHORS
-AUTHOR_EMAIL = 'erotemic@gmail.com'
-URL_LIST = [
-    'http://cmp.felk.cvut.cz/~perdom1/hesaff/',
-    'https://github.com/Erotemic/hesaff',
-]
-URL = 'https://github.com/Erotemic/hesaff'
-LICENSE = 'BSD'
+AUTHORS = ', '.join(ORIGINAL_AUTHORS + EXTENDED_AUTHORS + CURRENT_AUTHORS)
+AUTHOR_EMAIL = 'dev@wildme.org'
+URL = 'https://github.com/WildbookOrg/hesaff'
+LICENSE = 'APL 2.0'
 DESCRIPTION = 'Vtool - Image Tools for Wildbook IA'
 
 
 KWARGS = OrderedDict(
     name=NAME,
     version=VERSION,
-    author=', '.join(AUTHORS),
+    author=AUTHORS,
     author_email=AUTHOR_EMAIL,
     description=DESCRIPTION,
     long_description=parse_long_description('README.rst'),
     long_description_content_type='text/x-rst',
     url=URL,
     license=LICENSE,
-    install_requires=parse_requirements('requirements/runtime.txt'),
-    extras_require={
-        'all': parse_requirements('requirements.txt'),
-        'tests': parse_requirements('requirements/tests.txt'),
-        'build': parse_requirements('requirements/build.txt'),
-        'runtime': parse_requirements('requirements/runtime.txt'),
-    },
-
+    install_requires=parse_requirements('requirements.txt'),
+    extras_require={},
     # --- PACKAGES ---
     # The combination of packages and package_dir is how scikit-build will
     # know that the cmake installed files belong in the pyhesaff module and


### PR DESCRIPTION
This puts us on a path to make this fork WildMe specific. It's not changing the name of the package internally, but it is changing the outward facing package name to `wbia-pyhesaff`.

This also makes some minor changes to metadata, including author information and requirements.